### PR TITLE
Avoid measures overflowing viewport width

### DIFF
--- a/src/scss/_config.scss
+++ b/src/scss/_config.scss
@@ -96,8 +96,8 @@ $gorko-config: (
   ),
   'measure': (
     'items': (
-      'short': '48ch',
-      'long': '65ch'
+      'short': 'min(100%,48ch)',
+      'long': 'min(100%,65ch)'
     ),
     'output': 'responsive',
     'property': 'max-width'


### PR DESCRIPTION
not tested live, but this *should* result in a rendered CSS of `max-width: min(100%,65ch)` for `.post__body>*`, which will avoid having images in small-screen view bleeding off to the right (see for instance https://tink.uk/patrick-h-laukes-goulash/ on mobile)